### PR TITLE
Use registered mark instead of copyright mark

### DIFF
--- a/LaTeX/body/sample_usage.tex
+++ b/LaTeX/body/sample_usage.tex
@@ -42,7 +42,7 @@
 		\end{itemize}
 
 		\noindent
-		執筆に用いるソフトウェアに応じて、\LaTeX 版か Word \copyright 版を選択せよ。
+		執筆に用いるソフトウェアに応じて、\LaTeX 版か Word \textsuperscript{\textregistered} 版を選択せよ。
 		以下の節では、それぞれのフォーマットの使い方を説明する。
 
 	\section{LaTeX}


### PR DESCRIPTION
Superscript '®' might be more suitable than '©'.